### PR TITLE
never exit non-zero unless we say so

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Joscha Feth
+Copyright (c) 2020 Joscha Feth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ It contains a [post-command hook](hooks/command), and [tests](tests/command.bats
 ```yml
 steps:
   - plugins:
-      - joscha/codecov#v2.1.0: ~
+      - joscha/codecov#v2.1.1: ~
 ```
 
 The shell option can be used to forward parameters to the codecov invocation.
 ```yml
 steps:
   - plugins:
-      - joscha/codecov#v2.1.0:
+      - joscha/codecov#v2.1.1:
           args:
             - '-v'
             - '-F my_flag'

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -29,9 +29,13 @@ main() {
   pushd "${BUILDKITE_BUILD_CHECKOUT_PATH}" >/dev/null
 
   local args=()
+  local force_zero_exit=" || true"
   if plugin_read_list_into_result BUILDKITE_PLUGIN_CODECOV_ARGS ; then
     for arg in "${result[@]}" ; do
-      args+=("$arg")
+      args+=("${arg}")
+      if [[ "${arg}" == "-Z" ]]; then
+        force_zero_exit=""
+      fi
     done
   fi
 
@@ -45,7 +49,7 @@ main() {
       -it \
       --rm \
       buildpack-deps:jessie-scm \
-      bash -c "bash <(curl -s https://codecov.io/bash) ${args[*]:-}"
+      bash -c "bash <(curl -s https://codecov.io/bash) ${args[*]:-}${force_zero_exit}"
 
   popd >/dev/null
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -21,7 +21,7 @@ setup() {
   cd "$BUILDKITE_BUILD_CHECKOUT_PATH"
 
   stub docker \
-    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) ' : echo Ran Codecov in docker"
+    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash)  || true' : echo Ran Codecov in docker"
 
   run "$post_command_hook"
 
@@ -35,7 +35,20 @@ setup() {
   export BUILDKITE_PLUGIN_CODECOV_ARGS_1="-F my_flag"
 
   stub docker \
-    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) -v -F my_flag' : echo Ran Codecov in docker"
+    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) -v -F my_flag || true' : echo Ran Codecov in docker"
+
+  run "$post_command_hook"
+
+  assert_success
+  assert_output --partial "Ran Codecov in docker"
+}
+
+@test "Post-command succeeds with -Z" {
+  cd "$BUILDKITE_BUILD_CHECKOUT_PATH"
+  export BUILDKITE_PLUGIN_CODECOV_ARGS_0="-Z"
+
+  stub docker \
+    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) -Z' : echo Ran Codecov in docker"
 
   run "$post_command_hook"
 


### PR DESCRIPTION
see: https://docs.codecov.io/docs/about-the-codecov-bash-uploader

> Codecov will exit 0 to prevent failing the build, if there are issues. If you would like Codecov to exit with 1, use bash <(curl -s https://codecov.io/bash) -Z.
> exit 0 is not foolproof. Please use this command to always exit with 0: bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'.