### PR TITLE
fix: never fail plugin by default

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -29,18 +29,20 @@ main() {
   pushd "${BUILDKITE_BUILD_CHECKOUT_PATH}" >/dev/null
 
   local args=()
-  local force_zero_exit=" || true"
+  local force_zero_exit="true" # by default this plugin never fails
   if plugin_read_list_into_result BUILDKITE_PLUGIN_CODECOV_ARGS ; then
     for arg in "${result[@]}" ; do
       args+=("${arg}")
       if [[ "${arg}" == "-Z" ]]; then
-        force_zero_exit=""
+        force_zero_exit="false"
       fi
     done
   fi
 
   local ci_env
   ci_env=$(bash <(curl -s https://codecov.io/env))
+  set +e
+  local exit_code  
   docker run \
       $ci_env \
       --label "com.buildkite.job-id=${BUILDKITE_JOB_ID}" \
@@ -49,9 +51,14 @@ main() {
       -it \
       --rm \
       buildpack-deps:jessie-scm \
-      bash -c "bash <(curl -s https://codecov.io/bash) ${args[*]:-}${force_zero_exit}"
-
+      bash -c "bash <(curl -s https://codecov.io/bash) ${args[*]:-}"
+  exit_code="$?"
+  set -e
   popd >/dev/null
+
+  if [[ "${force_zero_exit}" != "true" ]]; then
+    exit "${exit_code}"
+  fi
 }
 
 main "$@"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -21,7 +21,7 @@ setup() {
   cd "$BUILDKITE_BUILD_CHECKOUT_PATH"
 
   stub docker \
-    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash)  || true' : echo Ran Codecov in docker"
+    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) ' : echo Ran Codecov in docker"
 
   run "$post_command_hook"
 
@@ -35,7 +35,7 @@ setup() {
   export BUILDKITE_PLUGIN_CODECOV_ARGS_1="-F my_flag"
 
   stub docker \
-    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) -v -F my_flag || true' : echo Ran Codecov in docker"
+    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir -it --rm buildpack-deps:jessie-scm bash -c 'bash <(curl -s https://codecov.io/bash) -v -F my_flag' : echo Ran Codecov in docker"
 
   run "$post_command_hook"
 


### PR DESCRIPTION
fixes when docker itself fails:

```
Unable to find image 'buildpack-deps:jessie-scm' locally
docker: Error response from daemon: Get https://registry-1.docker.io/v2/library/buildpack-deps/manifests/jessie-scm: dial tcp: lookup registry-1.docker.io: Temporary failure in name resolution.
See 'docker run --help'.
```