### PR TITLE
Retry curl to codecov.io

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -45,7 +45,8 @@ main() {
   fi
 
   local ci_env
-  ci_env=$(bash <(curl -s https://codecov.io/env))
+  ci_env=$(bash <(curl -s -S --connect-timeout 10 --retry 3 --retry-delay 10 https://codecov.io/env))
+
   set +e
   local exit_code  
   docker run \
@@ -56,7 +57,7 @@ main() {
       -it \
       --rm \
       buildpack-deps:jessie-scm \
-      bash -c "bash <(curl -s https://codecov.io/bash) ${args[*]:-}"
+      bash -c "bash <(curl -s -S --connect-timeout 10 --retry 3 --retry-delay 10 https://codecov.io/bash) ${args[*]:-}"
   exit_code="$?"
   set -e
   popd >/dev/null


### PR DESCRIPTION
coverage reports are not uploaded from time to time due to connection issues to https://codecov.io/env (see here: https://community.codecov.io/t/connection-timed-out/1715/8).
Simply adding some retries to `curl` fixes the issue in our case (until codecov will improve the reliability of their endpoints).