### PR TITLE
Parametrize buildkite codecov plugin docker image

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -145,7 +145,7 @@ main() {
       --volume=/tmp:/tmp \
       -it \
       --rm \
-      buildpack-deps:jessie-scm \
+      ${BUILDKITE_PLUGIN_CODECOV_DOCKER_IMAGE:-buildpack-deps:jessie-scm} \
       bash -c "${codecov_command} ${args[*]:-}"
   exit_code="$?"
   set -e

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,4 +16,6 @@ configuration:
       type: string
     tmp_dir:
       type: string
+    docker_image:
+      type: string
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -41,6 +41,18 @@ setup() {
   assert_output --partial "Ran Codecov in docker"
 }
 
+@test "Post-command succeeds with custom docker image" {
+  export BUILDKITE_PLUGIN_CODECOV_DOCKER_IMAGE="my/library/buildpack-deps:jessie-scm"
+
+  stub docker \
+    "run -e CODECOV_ENV -e CODECOV_TOKEN -e CODECOV_URL -e CODECOV_SLUG -e VCS_COMMIT_ID -e VCS_BRANCH_NAME -e VCS_PULL_REQUEST -e VCS_SLUG -e VCS_TAG -e CI_BUILD_URL -e CI_BUILD_ID -e CI_JOB_ID --label com.buildkite.job-id=${BUILDKITE_JOB_ID} --workdir=/workdir --volume=${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir --volume=/tmp:/tmp -it --rm my/library/buildpack-deps:jessie-scm bash -c '${codecov_command} ' : echo Ran Codecov in docker"
+
+  run "$post_command_hook"
+
+  assert_success
+  assert_output --partial "Ran Codecov in docker"
+}
+
 @test "Post-command succeeds with -Z" {
   export BUILDKITE_PLUGIN_CODECOV_ARGS_0="-Z"
 


### PR DESCRIPTION
We had an issue that sometimes we would hit the Docker hub pull rate limit and the current fix was to be able to use another image:
```
codecov: OK
env: OK
Unable to find image 'buildpack-deps:jessie-scm' locally
jessie-scm: Pulling from library/buildpack-deps
docker: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.
See 'docker run --help'
```