### PR TITLE
Try to find the PGP public key in BUILDKITE_PLUGINS_PATH

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -82,7 +82,8 @@ get_codecov_cli() {
 
   # One-time step
   if [[ "${BUILDKITE_PLUGIN_CODECOV_PGP_PUBLIC_KEY_URL-"false"}" = "" ]]; then
-    local pgp_key_path=$(find "${BUILDKITE_PLUGINS_PATH}" -name pgp_keys.asc | grep codecov-buildkite-plugin | head -1)
+    local pgp_key_path
+    pgp_key_path=$(find "${BUILDKITE_PLUGINS_PATH}" -name pgp_keys.asc | grep codecov-buildkite-plugin | head -1)
     if [[ -z "${pgp_key_path}" ]]; then
       error "Codecov's PGP public key not found in ${BUILDKITE_PLUGINS_PATH}"
     fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -82,8 +82,12 @@ get_codecov_cli() {
 
   # One-time step
   if [[ "${BUILDKITE_PLUGIN_CODECOV_PGP_PUBLIC_KEY_URL-"false"}" = "" ]]; then
-    debug "Importing bundled Codecov's PGP public key : $(pwd)/pgp_keys.asc" 
-    cat "$(pwd)/pgp_keys.asc" \
+    local pgp_key_path=$(find "${BUILDKITE_PLUGINS_PATH}" -name pgp_keys.asc | grep codecov-buildkite-plugin)
+    if [[ -z "${pgp_key_path}" ]]; then
+      error "Codecov's PGP public key not found in ${BUILDKITE_PLUGINS_PATH}"
+    fi
+    debug "Importing bundled Codecov's PGP public key : ${pgp_key_path}"
+    cat "${pgp_key_path}" \
       | gpg \
           --no-default-keyring \
           --keyring trustedkeys.gpg \

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -82,7 +82,7 @@ get_codecov_cli() {
 
   # One-time step
   if [[ "${BUILDKITE_PLUGIN_CODECOV_PGP_PUBLIC_KEY_URL-"false"}" = "" ]]; then
-    local pgp_key_path=$(find "${BUILDKITE_PLUGINS_PATH}" -name pgp_keys.asc | grep codecov-buildkite-plugin)
+    local pgp_key_path=$(find "${BUILDKITE_PLUGINS_PATH}" -name pgp_keys.asc | grep codecov-buildkite-plugin | head -1)
     if [[ -z "${pgp_key_path}" ]]; then
       error "Codecov's PGP public key not found in ${BUILDKITE_PLUGINS_PATH}"
     fi


### PR DESCRIPTION
@joscha keybase.io is being annoying and we are getting errors sporadically:
```
Downloading and importing Codecov's PGP public key from : https://keybase.io/codecovsecurity/pgp_keys.asc
curl: (56) Failure when receiving data from the peer
```

So now I'm trying to use the bundled key.

My previous [PR](https://github.com/joscha/codecov-buildkite-plugin/pull/28) was naively hoping to find the key in `"$(pwd)/pgp_keys.asc"` in case we use `pgp_public_key_url: ''`. 
However, `$(pwd)` is the working directly of the repo and not the plugin and this does not work.

In this PR, I'm trying to find the PGP public key in `BUILDKITE_PLUGINS_PATH` if `pgp_public_key_url: ''` is specified.

I've tested it on our CI and this works fine:
```
Importing bundled Codecov's PGP public key : ...
```

